### PR TITLE
Roku detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 npm-debug.log
 node_modules
+out

--- a/keymaps/roku-deploy.cson
+++ b/keymaps/roku-deploy.cson
@@ -9,3 +9,4 @@
 # https://atom.io/docs/latest/behind-atom-keymaps-in-depth
 'atom-workspace':
   'ctrl-alt-shift-d': 'roku-deploy:deployRoku'
+  'ctrl-alt-shift-s': 'roku-deploy:searchDevices'

--- a/lib/roku-deploy.coffee
+++ b/lib/roku-deploy.coffee
@@ -1,4 +1,5 @@
 RokuDeployView = require './roku-deploy-view'
+RokuDetector = require './roku-detect'
 {CompositeDisposable} = require 'atom'
 fs = require 'fs'
 Archiver = require 'archiver'
@@ -15,21 +16,27 @@ module.exports = RokuDeploy =
   outputDirectory: null
   separator: if process.platform != 'win32' then '/' else '\\'
   config:
-      rokuAddress:
-          type: 'string'
-          default: '192.168.1.1'
-      rokuUserId:
-          type: 'string'
-          default: 'rokudev'
-      rokuPassword:
-          type: 'string'
-          default: '1111'
-      excludedPaths:
-          type: 'string'
-          default: 'out'
-      outputDirectory:
-          type: 'string'
-          default: 'out'
+    availableRokus:
+      title: 'Available Devices'
+      type: 'string'
+      default: 'None'
+      description: 'Roku devices detected in your local network'
+      enum: ['None']
+    rokuAddress:
+      type: 'string'
+      default: '192.168.1.1'
+    rokuUserId:
+      type: 'string'
+      default: 'rokudev'
+    rokuPassword:
+      type: 'string'
+      default: '1111'
+    excludedPaths:
+      type: 'string'
+      default: 'out'
+    outputDirectory:
+      type: 'string'
+      default: 'out'
 
   activate: (state) ->
     @rokuDeployView = new RokuDeployView(state.rokuDeployViewState)

--- a/lib/roku-deploy.coffee
+++ b/lib/roku-deploy.coffee
@@ -5,7 +5,8 @@ fs = require 'fs'
 Archiver = require 'archiver'
 request = require 'request'
 
-module.exports = RokuDeploy =
+
+module.exports =
   rokuDeployView: null
   modalPanel: null
   subscriptions: null
@@ -15,13 +16,15 @@ module.exports = RokuDeploy =
   excludedPaths: null
   outputDirectory: null
   separator: if process.platform != 'win32' then '/' else '\\'
-  config:
-    availableRokus:
+  #config to be defined on activation
+  devices : []
+  # inital config
+  config :
+    devices:
       title: 'Available Devices'
-      type: 'string'
-      default: 'None'
+      type: 'array'
+      default: ['192.168.1.1']
       description: 'Roku devices detected in your local network'
-      enum: ['None']
     rokuAddress:
       type: 'string'
       default: '192.168.1.1'
@@ -39,6 +42,15 @@ module.exports = RokuDeploy =
       default: 'out'
 
   activate: (state) ->
+    RokuDetector.detectDevices((ip) =>
+      @devices.push ip
+      devices = @devices.map (device) -> device.model
+      console.log @devices
+      atom.config.set 'roku-deploy.devices', devices
+    )
+    @setup state
+
+  setup:(state) ->
     @rokuDeployView = new RokuDeployView(state.rokuDeployViewState)
     @modalPanel = atom.workspace.addModalPanel(item: @rokuDeployView.getElement(), visible: false)
     @rokuAddress = atom.config.get('roku-deploy.rokuAddress')
@@ -66,91 +78,91 @@ module.exports = RokuDeploy =
 
 
   zipPackage: ->
-      console.log 'zipPackage called.'
-      request.post('http://' + module.exports.rokuAddress + ':8060/keypress/Home').on('response', (response)->
+    console.log 'zipPackage called.'
+    request.post('http://' + module.exports.rokuAddress + ':8060/keypress/Home').on('response', (response)->
+      if response != undefined
+        console.log "Response returned"
+        if response != undefined && response.statusCode != undefined && response.statusCode == 200
+          console.log "Response returned 200"
+          module.exports.zipCore()
+        else
+          atom.notifications.addError('Sending Home command did not succeed. See console for details.')
           if response != undefined
-              console.log "Response returned"
-              if response != undefined && response.statusCode != undefined && response.statusCode == 200
-                  console.log "Response returned 200"
-                  module.exports.zipCore()
-              else
-                  atom.notifications.addError('Sending Home command did not succeed. See console for details.')
-                  if response != undefined
-                      console.log response.body
-          else
-              console.log "No response returned."
-      )
+            console.log response.body
+      else
+        console.log "No response returned."
+    )
 
   zipCore: ->
-      dirs = atom.project.getDirectories()
-      dir = dirs[0]
-      if(dir!=undefined)
-          p = dir.getRealPathSync()
-          bundlePath = p + @separator + @outputDirectory + @separator
-          try
-              stat = fs.lstatSync(bundlePath)
-          catch error
-              console.log 'out directory not found, creating.'
-              fs.mkdirSync(bundlePath)
-              stat = fs.lstatSync(bundlePath)
-              if(not stat.isDirectory())
-                  console.log 'failed to create out directory.'
-                  return
+    dirs = atom.project.getDirectories()
+    dir = dirs[0]
+    if(dir!=undefined)
+      p = dir.getRealPathSync()
+      bundlePath = p + @separator + @outputDirectory + @separator
+      try
+        stat = fs.lstatSync(bundlePath)
+      catch error
+        console.log 'out directory not found, creating.'
+        fs.mkdirSync(bundlePath)
+        stat = fs.lstatSync(bundlePath)
+        if(not stat.isDirectory())
+          console.log 'failed to create out directory.'
+          return
 
-          zipFile = fs.createWriteStream(bundlePath+'bundle.zip')
-          @zip = Archiver('zip')
-          zipFile.on('close',@zipComplete)
-          @zip.on('error',(err) -> throw err)
-          @zip.pipe(zipFile)
-          splitExcludedPaths = @excludedPaths.split(',')
-          upperExcludedPaths = []
-          splitExcludedPaths.forEach (ep) -> upperExcludedPaths.push(ep.trim().toLocaleUpperCase())
-          @addToZip directory for directory in dir.getEntriesSync() when directory.isDirectory() and upperExcludedPaths.indexOf(directory.getBaseName().toLocaleUpperCase()) == -1 and not directory.getBaseName().startsWith('.')
-          params = {expand: true, cwd: dir.getRealPathSync(), src: ['manifest'],dest:''}
-          @zip.bulk params
-      @zip.finalize()
+      zipFile = fs.createWriteStream(bundlePath+'bundle.zip')
+      @zip = Archiver('zip')
+      zipFile.on('close',@zipComplete)
+      @zip.on('error',(err) -> throw err)
+      @zip.pipe(zipFile)
+      splitExcludedPaths = @excludedPaths.split(',')
+      upperExcludedPaths = []
+      splitExcludedPaths.forEach (ep) -> upperExcludedPaths.push(ep.trim().toLocaleUpperCase())
+      @addToZip directory for directory in dir.getEntriesSync() when directory.isDirectory() and upperExcludedPaths.indexOf(directory.getBaseName().toLocaleUpperCase()) == -1 and not directory.getBaseName().startsWith('.')
+      params = {expand: true, cwd: dir.getRealPathSync(), src: ['manifest'],dest:''}
+      @zip.bulk params
+    @zip.finalize()
 
   zipComplete: ->
-      console.log "Zipping complete"
-      atom.notifications.addInfo("Bundling completed. Starting deploy . . .")
-      addrs = 'http://'+ module.exports.rokuAddress + '/plugin_install'
-      console.log  addrs
-      dirs = atom.project.getDirectories()
-      dir = dirs[0]
-      p = dir.getRealPathSync()
-      bundlePath = p + module.exports.separator  + module.exports.outputDirectory + module.exports.separator
-      rokuOptions =
-          url : addrs
-          formData :
-              mysubmit : 'Replace'
-              archive : fs.createReadStream(bundlePath+'bundle.zip')
-      request.post(rokuOptions,module.exports.requestCallback).auth(module.exports.rokuUserId,module.exports.rokuPassword,false)
-      console.log 'Request started'
+    console.log "Zipping complete"
+    atom.notifications.addInfo("Bundling completed. Starting deploy . . .")
+    addrs = 'http://'+ module.exports.rokuAddress + '/plugin_install'
+    console.log addrs
+    dirs = atom.project.getDirectories()
+    dir = dirs[0]
+    p = dir.getRealPathSync()
+    bundlePath = p + module.exports.separator + module.exports.outputDirectory + module.exports.separator
+    rokuOptions =
+      url : addrs
+      formData :
+        mysubmit : 'Replace'
+        archive : fs.createReadStream(bundlePath+'bundle.zip')
+    request.post(rokuOptions,module.exports.requestCallback).auth(module.exports.rokuUserId,module.exports.rokuPassword,false)
+    console.log 'Request started'
 
 
   requestCallback: (error,response,body) ->
-      if response != undefined && response.statusCode != undefined && response.statusCode == 200
-          if response.body.indexOf("Identical to previous version -- not replacing.") != -1
-              atom.notifications.addWarning("Deploy cancelled by Roku: the package is identical to the package already on the Roku.")
-          else
-              console.log "Successfully deployed"
-              atom.notifications.addSuccess('Deployed to '+module.exports.rokuAddress)
+    if response != undefined && response.statusCode != undefined && response.statusCode == 200
+      if response.body.indexOf("Identical to previous version -- not replacing.") != -1
+        atom.notifications.addWarning("Deploy cancelled by Roku: the package is identical to the package already on the Roku.")
       else
-          atom.notifications.addFatalError("Failed to deploy to " + module.exports.rokuAddress + " see console output for details.")
-          console.log error
-          if response != undefined
-              console.log response.body
+        console.log "Successfully deployed"
+        atom.notifications.addSuccess('Deployed to '+module.exports.rokuAddress)
+    else
+      atom.notifications.addFatalError("Failed to deploy to " + module.exports.rokuAddress + " see console output for details.")
+      console.log error
+      if response != undefined
+        console.log response.body
 
   setRokuAddress: (address, userId,pwd)->
-      module.exports.rokuAddress = address
-      module.exports.rokuUserId = userId
-      moduel.exports.rokuPassword = pwd
+    module.exports.rokuAddress = address
+    module.exports.rokuUserId = userId
+    moduel.exports.rokuPassword = pwd
     #   Diplay input for setting roku address
 
   deployRoku: ->
-      @rokuAddress = atom.config.get('roku-deploy.rokuAddress')
-      @rokuUserId = atom.config.get('roku-deploy.rokuUserId')
-      @rokuPassword = atom.config.get('roku-deploy.rokuPassword')
-      @excludedPaths = atom.config.get('roku-deploy.excludedPaths')
-      @outputDirectory = atom.config.get('roku-deploy.outputDirectory')
-      @zipPackage()
+    @rokuAddress = atom.config.get('roku-deploy.rokuAddress')
+    @rokuUserId = atom.config.get('roku-deploy.rokuUserId')
+    @rokuPassword = atom.config.get('roku-deploy.rokuPassword')
+    @excludedPaths = atom.config.get('roku-deploy.excludedPaths')
+    @outputDirectory = atom.config.get('roku-deploy.outputDirectory')
+    @zipPackage()

--- a/lib/roku-detect.coffee
+++ b/lib/roku-detect.coffee
@@ -1,12 +1,30 @@
-Client = require('node-ssdp').Client
+{ Client } = require 'node-ssdp'
+request = require 'request'
+cheerio = require 'cheerio'
+PORT = 8060;
 
 module.exports =
-    detectRoku: ()->
-	    client = new Client()
+    detect: detectRoku
 
-	    client.on('response',(headers, statusCode, rinfo) ->
-	        console.log 'Roku detected'
-	        console.log(rinfo);
-	    )
 
-	    client.search('roku:ecp')
+detectRoku() ->
+    client = new Client
+    #process response
+    client.on('response', (headers, statusCode, rinfo) ->
+        if (rinfo.address)
+            requestDeviceData rinfo.address
+    )
+    # search for roku devices
+    client.search 'roku:ecp'
+}
+
+requestDeviceData(ip) ->
+    url = "http://#{ip}:#{PORT}";
+
+    request(url, (error, response, body) ->
+        if (!error && response.statusCode == 200)
+            $ = cheerio.load body
+            console.log 'Found:', $('device > friendlyName').text(),'@',ip
+        else
+            console.log 'error!'
+    )

--- a/lib/roku-detect.coffee
+++ b/lib/roku-detect.coffee
@@ -1,0 +1,12 @@
+Client = require('node-ssdp').Client
+
+module.exports =
+    detectRoku: ()->
+	    client = new Client()
+
+	    client.on('response',(headers, statusCode, rinfo) ->
+	        console.log 'Roku detected'
+	        console.log(rinfo);
+	    )
+
+	    client.search('roku:ecp')

--- a/lib/roku-detect.coffee
+++ b/lib/roku-detect.coffee
@@ -4,27 +4,25 @@ cheerio = require 'cheerio'
 PORT = 8060;
 
 module.exports =
-    detect: detectRoku
+    detectDevices : (callback) ->
+        client = new Client
+        #process response
+        client.on('response', (headers, statusCode, rinfo) ->
+            if (rinfo.address)
+                @requestDeviceData rinfo.address, callback
+        )
+        # search for roku devices
+        client.search 'roku:ecp'
 
 
-detectRoku() ->
-    client = new Client
-    #process response
-    client.on('response', (headers, statusCode, rinfo) ->
-        if (rinfo.address)
-            requestDeviceData rinfo.address
-    )
-    # search for roku devices
-    client.search 'roku:ecp'
-}
+    requestDeviceData : (ip, callback) ->
+        url = "http://#{ip}:#{PORT}";
 
-requestDeviceData(ip) ->
-    url = "http://#{ip}:#{PORT}";
-
-    request(url, (error, response, body) ->
-        if (!error && response.statusCode == 200)
-            $ = cheerio.load body
-            console.log 'Found:', $('device > friendlyName').text(),'@',ip
-        else
-            console.log 'error!'
-    )
+        request(url, (error, response, body) ->
+            if (not error and response.statusCode is 200)
+                $ = cheerio.load body
+                console.log 'Found:', $('device > friendlyName').text(),'@',ip
+                callback?(ip)
+            else
+                console.log 'error!'
+        )

--- a/lib/roku-search-view.coffee
+++ b/lib/roku-search-view.coffee
@@ -1,0 +1,51 @@
+Template = require '../templates/view'
+DELAY = 5000
+
+module.exports =
+class RokuSearchView
+  constructor: (targetConfig, defaultCallback) ->
+    # Create root element
+    @element = document.createElement 'div'
+    # TODO: require html is giving errors, therefor the template is just an string
+    # update this to require a real html fragment
+    @element.innerHTML = Template
+    @devices = @element.querySelector '[name]'
+    @spinner = @element.querySelector '.loading'
+    @actionButtons = @element.querySelector '[data-actions]'
+    @targetConfig = targetConfig
+    @defaultCallback = defaultCallback
+    do @setup
+
+
+  setup:(eventResponder = (e) -> console.log e) ->
+    @devices.addEventListener 'change', eventResponder
+    @actionButtons.addEventListener 'click', (e)=> @onClick e
+    @setLoadingStatus
+
+
+  onClick:(e)->
+    button = e.target
+    if button.matches('[data-confirm]')
+      atom.config.set @targetConfig, @devices.value
+      console.log atom.config.get @targetConfig
+    do @defaultCallback
+
+
+  setLoadingStatus: (visible = yes)->
+    @spinner.style.visibility = if visible then 'visible' else 'hidden'
+
+
+  # Tear down any state and detach
+  destroy: ->
+    do @element.remove
+
+
+  getElement: ->
+    @element
+
+
+  addDevice:(device = { name : 'None' , ip : '' })->
+    # receive device and create option element
+    @devices.innerHTML += "<option value='#{device.ip}'>#{device.name}</option>"
+    do @setLoadingStatus
+    setTimeout ()=> @setLoadingStatus no, DELAY

--- a/menus/roku-deploy.cson
+++ b/menus/roku-deploy.cson
@@ -13,6 +13,10 @@
       'label': 'roku-deploy'
       'submenu': [
         {
+          'label': 'Seach Available Devices'
+          'command': 'roku-deploy:getDevices'
+        }
+        {
           'label': 'Deploy'
           'command': 'roku-deploy:deployRoku'
         }

--- a/menus/roku-deploy.cson
+++ b/menus/roku-deploy.cson
@@ -2,7 +2,7 @@
 'context-menu':
   'atom-text-editor': [
     {
-      'label': 'Deploy roku-deploy'
+      'label': 'Deploy to Roku'
       'command': 'roku-deploy:deployRoku'
     }
   ]
@@ -10,14 +10,14 @@
   {
     'label': 'Packages'
     'submenu': [
-      'label': 'roku-deploy'
+      'label': 'Roku Deploy'
       'submenu': [
         {
           'label': 'Seach Available Devices'
-          'command': 'roku-deploy:getDevices'
+          'command': 'roku-deploy:searchDevices'
         }
         {
-          'label': 'Deploy'
+          'label': 'Deploy to Roku'
           'command': 'roku-deploy:deployRoku'
         }
       ]

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "archiver": "^0.21.0",
     "request": "^2.69.0",
-    "node-ssdp": "^2.8.0"
+    "node-ssdp": "^2.8.0",
+    "cheerio": "^0.22.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "archiver": "^0.21.0",
-    "request": "^2.69.0"
+    "request": "^2.69.0",
+    "node-ssdp": "^2.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,21 +1,22 @@
 {
-  "name": "roku-deploy",
-  "main": "./lib/roku-deploy",
-  "version": "0.3.7",
-  "description": "A simple package to deploy to roku from Atom.",
-  "keywords": [],
-  "activationCommands": {
-    "atom-workspace": "roku-deploy:deployRoku"
-  },
-  "repository": "https://github.com/mmratio/roku-deploy",
-  "license": "MIT",
-  "engines": {
-    "atom": ">=1.0.0 <2.0.0"
-  },
-  "dependencies": {
-    "archiver": "^0.21.0",
-    "request": "^2.69.0",
-    "node-ssdp": "^2.8.0",
-    "cheerio": "^0.22.0"
-  }
+    "name": "roku-deploy",
+    "main": "./lib/roku-deploy",
+    "version": "0.4.0",
+    "description": "A simple package to deploy to roku from Atom.",
+    "keywords": [],
+    "activationCommands": {
+        "atom-workspace": "roku-deploy:deployRoku",
+        "atom-workspace": "roku-deploy:deployRoku"
+    },
+    "repository": "https://github.com/mmratio/roku-deploy",
+    "license": "MIT",
+    "engines": {
+        "atom": ">=1.0.0 <2.0.0"
+    },
+    "dependencies": {
+        "archiver": "^0.21.0",
+        "request": "^2.69.0",
+        "node-ssdp": "^2.8.0",
+        "cheerio": "^0.22.0"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
     "description": "A simple package to deploy to roku from Atom.",
     "keywords": [],
     "activationCommands": {
-        "atom-workspace": "roku-deploy:deployRoku",
-        "atom-workspace": "roku-deploy:deployRoku"
+        "atom-workspace": ["roku-deploy:deployRoku", "roku-deploy:searchDevices"]
     },
     "repository": "https://github.com/mmratio/roku-deploy",
     "license": "MIT",

--- a/styles/roku-deploy.less
+++ b/styles/roku-deploy.less
@@ -4,5 +4,6 @@
 // for a full listing of what's available.
 @import "ui-variables";
 
-.roku-deploy {
+.devices-select{
+	width: 94%;
 }

--- a/templates/view.js
+++ b/templates/view.js
@@ -1,0 +1,17 @@
+// using a js string since requiring an html file is failing :\
+module.exports =`<div class="controls block">
+	<div class="block">
+		<h3>Select Roku Device as Deploy Target</h3>
+		<div class="block">
+			<select name="devices" class="form-control devices-select inline-block">
+				<option value="None">None</option>
+			</select>
+			<span class='loading loading-spinner-tiny inline-block'></span>
+		</div>
+		<p>The selected Roku device ip will be set as the target address for deploy</p>
+	</div>
+	<div class='block' data-actions>
+		 <button data-confirm="true" class='btn icon primary device-desktop inline-block-tight'>Confirm Roku Selection</button>
+		 <button class='btn icon x inline-block-tight'>Cancel</button>
+	</div>
+</div>`


### PR DESCRIPTION
adding a new feature to Roku-Deploy, now we can detect the Roku devices present on your local network based on what is provided by External Control Guide (https://sdkdocs.roku.com/display/sdkdoc/External+Control+Guide) and once it is selected, confirmation of it will update the roku address setting for package.

Some additional changes apart from feature addition:
- label changes for context menus (Roku Deploy instead of roku-deploy)
- you can trigger the Roku search with **ctrl+shift+alt+s**
- "coffeeing" some lines which looked more like js than cs
